### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN \
   yum clean all && \
   rm -rf /root/.sbt /root/.ivy2 /tmp/*
 
-COPY start.sh /start.sh
+COPY ./start.sh /start.sh
 
 EXPOSE 9000
 


### PR DESCRIPTION
Builds on docker hub failed without this leading ./. I'm not sure if it's actually required now, or if simply forcing a retry is what's needed.
